### PR TITLE
Skip building docker files if they haven't changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Prepare environment variables
         run: |
-          git log -1 --stat --oneline
+          cat $GITHUB_EVENT_PATH
+          git diff --name-only $GITHUB_SHA^..$GITHUB_SHA
           git log -1 --stat --oneline | grep -c Docker
           echo ::set-env name=BRANCH_REF::"$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')"
           echo ::set-env name=BASE_IMAGE::ubuntu:18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Prepare environment variables
         run: |
+          git log -1 --stat --oneline | grep -c Docker
           echo ::set-env name=BRANCH_REF::"$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')"
           echo ::set-env name=BASE_IMAGE::ubuntu:18.04
           echo ::set-env name=CORE_IMAGE::dependabot/dependabot-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           echo ::set-env name=BASE_IMAGE::ubuntu:18.04
           echo ::set-env name=CORE_IMAGE::dependabot/dependabot-core
           echo ::set-env name=CORE_CI_IMAGE::dependabot/dependabot-core-ci
+          echo ::set-env name=DOCKER_HAS_CHANGED::"$(git log -1 --stat --oneline | grep -c Docker)"
       - name: Log in to Docker registry
         run: |
           if [ -n "${{ secrets.DOCKER_USERNAME }}" ] && [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then
@@ -60,6 +61,7 @@ jobs:
           docker pull "$CORE_CI_IMAGE:ci--$BRANCH_REF" ||
             "$CORE_CI_IMAGE:latest" || true
       - name: Build dependabot-core image
+        if: env.DOCKER_HAS_CHANGED != '0'
         run: |
           docker build \
             -t "$CORE_IMAGE:latest" \
@@ -74,6 +76,7 @@ jobs:
         run: |
           docker push "$CORE_CI_IMAGE:core--$BRANCH_REF"
       - name: Build dependabot-core-ci image
+        if: env.DOCKER_HAS_CHANGED != '0'
         run: |
           rm .dockerignore
           docker build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Prepare environment variables
         run: |
+          git log -1 --stat --oneline
           git log -1 --stat --oneline | grep -c Docker
           echo ::set-env name=BRANCH_REF::"$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')"
           echo ::set-env name=BASE_IMAGE::ubuntu:18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,19 @@ jobs:
         uses: actions/checkout@v2
       - name: Prepare environment variables
         run: |
-          cat $GITHUB_EVENT_PATH
-          git diff --name-only $GITHUB_SHA^..$GITHUB_SHA
+          git log -n 5
+
           git log -1 --stat --oneline | grep -c Docker
           echo ::set-env name=BRANCH_REF::"$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')"
           echo ::set-env name=BASE_IMAGE::ubuntu:18.04
           echo ::set-env name=CORE_IMAGE::dependabot/dependabot-core
           echo ::set-env name=CORE_CI_IMAGE::dependabot/dependabot-core-ci
-          echo ::set-env name=DOCKER_HAS_CHANGED::"$(git log -1 --stat --oneline | grep -c Docker)"
+          GIT_START_RANGE=HEAD~1
+          if [ -n "$GITHUB_BASE_REF" ]; then
+            GIT_START_RANGE=$GITHUB_BASE_REF
+          fi
+          git diff --name-only $GIT_START_RANGE..HEAD
+          echo ::set-env name=DOCKER_HAS_CHANGED::"$(git diff --name-only $GIT_START_RANGE..HEAD | grep -c Docker)"
       - name: Log in to Docker registry
         run: |
           if [ -n "${{ secrets.DOCKER_USERNAME }}" ] && [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then


### PR DESCRIPTION
Looks like a lost cause for now since we will need to build the image when we're in a branch that has changed the Dockerfile but isn't yet in the master branch.